### PR TITLE
Improve revsearch

### DIFF
--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -313,7 +313,11 @@ function operate(spec, done) {
           }
 
           if ('search' === state.connection.mode) {
-            if (key) { // NOTE: sometimes `key` is undefined (e.g. when an arrow-key is pressed)
+            if (spec.name === 'backspace') {
+              state.connection.search = state.connection.search.slice(0, -1)
+	    } else if (spec.ctrl && spec.name === 'u') {
+	      state.connection.search = ''
+	    } else if (key) { // NOTE: sometimes `key` is undefined (e.g. when an arrow-key is pressed)
 	      let cc = key.charCodeAt(0)
 	      if (31 < cc || 8 === cc) {
 		if (127 === cc || 8 === cc) {

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -343,6 +343,7 @@ function operate(spec, done) {
                     if (0 === offset) {
                       state.connection.readline.write(searchprompt + history[i])
                       state.connection.found = history[i]
+		      Readline.moveCursor(process.stdout, -(2 + history[i].length))
                       break
                     } else {
                       offset--
@@ -353,12 +354,14 @@ function operate(spec, done) {
 
               if ('' === state.connection.found) {
                 state.connection.readline.write(searchprompt)
+                Readline.moveCursor(process.stdout, -2)
               }
             })
           } else if ('r' == spec.name && spec.ctrl) {
             state.connection.readline.pause()
             state.connection.readline.setPrompt('search: [] ')
             state.connection.readline.prompt()
+	    Readline.moveCursor(process.stdout, -2)
             state.connection.mode = 'search'
             state.connection.search = ''
             state.connection.offset = 0

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -338,6 +338,7 @@ function operate(spec, done) {
               Readline.clearLine(process.stdout, 0)
 	      state.connection.readline.line = ''
 
+              const DISTANCE_TO_REVSEARCH_BOX = 2
               const searchprompt = 'search: [' + search + '] '
               // state.connection.readline.write(searchprompt)
 
@@ -349,7 +350,7 @@ function operate(spec, done) {
                     if (0 === offset) {
                       state.connection.readline.write(searchprompt + history[i])
                       state.connection.found = history[i]
-                      Readline.moveCursor(process.stdout, -(2 + history[i].length))
+                      Readline.moveCursor(process.stdout, -(DISTANCE_TO_REVSEARCH_BOX + history[i].length))
                       break
                     } else {
                       offset--
@@ -360,14 +361,14 @@ function operate(spec, done) {
 
               if ('' === state.connection.found) {
                 state.connection.readline.write(searchprompt)
-                Readline.moveCursor(process.stdout, -2)
+                Readline.moveCursor(process.stdout, -DISTANCE_TO_REVSEARCH_BOX)
               }
             })
           } else if ('r' == spec.name && spec.ctrl) {
             state.connection.readline.pause()
             state.connection.readline.setPrompt('search: [] ')
             state.connection.readline.prompt()
-            Readline.moveCursor(process.stdout, -2)
+            Readline.moveCursor(process.stdout, -DISTANCE_TO_REVSEARCH_BOX)
             state.connection.mode = 'search'
             state.connection.search = ''
             state.connection.offset = 0

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -349,7 +349,7 @@ function operate(spec, done) {
                     if (0 === offset) {
                       state.connection.readline.write(searchprompt + history[i])
                       state.connection.found = history[i]
-		      Readline.moveCursor(process.stdout, -(2 + history[i].length))
+                      Readline.moveCursor(process.stdout, -(2 + history[i].length))
                       break
                     } else {
                       offset--
@@ -367,7 +367,7 @@ function operate(spec, done) {
             state.connection.readline.pause()
             state.connection.readline.setPrompt('search: [] ')
             state.connection.readline.prompt()
-	    Readline.moveCursor(process.stdout, -2)
+            Readline.moveCursor(process.stdout, -2)
             state.connection.mode = 'search'
             state.connection.search = ''
             state.connection.offset = 0

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -313,18 +313,20 @@ function operate(spec, done) {
           }
 
           if ('search' === state.connection.mode) {
-            let cc = key.charCodeAt(0)
-            if (31 < cc || 8 === cc) {
-              if (127 === cc || 8 === cc) {
-                // state.connection.search =
-                //  state.connection.search.substring(0,state.connection.search.length-1)
-                // state.connection.offset = 0
-              } else {
-                state.connection.search += key
-              }
-            } else if ('r' == spec.name && spec.ctrl) {
-              state.connection.offset++
-            }
+            if (key) { // NOTE: sometimes `key` is undefined (e.g. when an arrow-key is pressed)
+	      let cc = key.charCodeAt(0)
+	      if (31 < cc || 8 === cc) {
+		if (127 === cc || 8 === cc) {
+		  // state.connection.search =
+		  //  state.connection.search.substring(0,state.connection.search.length-1)
+		  // state.connection.offset = 0
+		} else {
+		  state.connection.search += key
+		}
+	      } else if ('r' == spec.name && spec.ctrl) {
+		state.connection.offset++
+	      }
+	    }
 
             let search = state.connection.search
 

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -377,6 +377,8 @@ function operate(spec, done) {
         state.connection.readline
           .on('line', (line) => {
             if ('search' === state.connection.mode) {
+              history.shift() // NOTE: here we are removing the revsearch prompt from the history
+
               Readline.cursorTo(process.stdin, 0)
               Readline.clearLine(process.stdin, 1)
               state.connection.readline.setPrompt(state.connection.prompt)

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -329,7 +329,8 @@ function operate(spec, done) {
             let search = state.connection.search
 
             Readline.cursorTo(process.stdout, 0, () => {
-              Readline.clearLine(process.stdout, 1)
+              Readline.clearLine(process.stdout, 0)
+	      state.connection.readline.line = ''
 
               const searchprompt = 'search: [' + search + '] '
               // state.connection.readline.write(searchprompt)

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -328,8 +328,8 @@ function operate(spec, done) {
 
             let search = state.connection.search
 
-            Readline.cursorTo(process.stdin, 0, () => {
-              Readline.clearLine(process.stdin, 1)
+            Readline.cursorTo(process.stdout, 0, () => {
+              Readline.clearLine(process.stdout, 1)
 
               const searchprompt = 'search: [' + search + '] '
               // state.connection.readline.write(searchprompt)

--- a/bin/seneca-repl-exec.js
+++ b/bin/seneca-repl-exec.js
@@ -17,6 +17,9 @@ const { minify_sync } = require('terser')
 const JP = (arg) => JSON.parse(arg)
 const JS = (a0, a1) => JSON.stringify(a0, a1)
 
+const makesearchprompt = search => 'search: [' + search + '] '
+const DISTANCE_TO_SEARCH_BOX = 2
+
 const state = {
   connection: {
     mode: 'cmd',
@@ -338,8 +341,6 @@ function operate(spec, done) {
               Readline.clearLine(process.stdout, 0)
 	      state.connection.readline.line = ''
 
-              const DISTANCE_TO_REVSEARCH_BOX = 2
-              const searchprompt = 'search: [' + search + '] '
               // state.connection.readline.write(searchprompt)
 
               state.connection.found = ''
@@ -348,9 +349,9 @@ function operate(spec, done) {
                 for (let i = 0; i < history.length; i++) {
                   if (history[i].includes(search)) {
                     if (0 === offset) {
-                      state.connection.readline.write(searchprompt + history[i])
+                      state.connection.readline.write(makesearchprompt(search) + history[i])
                       state.connection.found = history[i]
-                      Readline.moveCursor(process.stdout, -(DISTANCE_TO_REVSEARCH_BOX + history[i].length))
+                      Readline.moveCursor(process.stdout, -(DISTANCE_TO_SEARCH_BOX + history[i].length))
                       break
                     } else {
                       offset--
@@ -360,15 +361,15 @@ function operate(spec, done) {
               }
 
               if ('' === state.connection.found) {
-                state.connection.readline.write(searchprompt)
-                Readline.moveCursor(process.stdout, -DISTANCE_TO_REVSEARCH_BOX)
+                state.connection.readline.write(makesearchprompt(search))
+                Readline.moveCursor(process.stdout, -DISTANCE_TO_SEARCH_BOX)
               }
             })
           } else if ('r' == spec.name && spec.ctrl) {
             state.connection.readline.pause()
             state.connection.readline.setPrompt('search: [] ')
             state.connection.readline.prompt()
-            Readline.moveCursor(process.stdout, -DISTANCE_TO_REVSEARCH_BOX)
+            Readline.moveCursor(process.stdout, -DISTANCE_TO_SEARCH_BOX)
             state.connection.mode = 'search'
             state.connection.search = ''
             state.connection.offset = 0


### PR DESCRIPTION
- solves the problem of garbage being printed out when using the revsearch, e.g.:
```
search: [] asearch: [a] git statusasearch: [aa] aaadsaasearch: [aaa] aaadsaasearch: [aaaa] aaaaaaasearch: [aaaaa] aaaaaaasearch: [a
search: [aaaaaaaa]
```
- positions the user's cursor inside the search box to look nicely
- fixes a crash when a user presses an arrow-key inside the revsearch box
- adds support for erasing text via the Backspace key
- adds support for the Ctrl+U combination
- removes the revsearch search prompt from the terminal history
